### PR TITLE
Add missing import in readme code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ More documentation in the [Wiki](https://github.com/Hellenic/react-hexgrid/wiki)
 ## Example
 
 ```html
-import { HexGrid, Layout, Hexagon, Text, Pattern } from 'react-hexgrid';
+import { HexGrid, Layout, Hexagon, Text, Pattern, Path, Hex } from 'react-hexgrid';
 import './App.css';
 
 class App extends Component {


### PR DESCRIPTION
After copy pasted the readme example, I get an error.