### PR TITLE
Fixed a bug plus added two layout examples

### DIFF
--- a/examples/templates/src/App.js
+++ b/examples/templates/src/App.js
@@ -28,13 +28,12 @@ class App extends Component {
       <div className="App">
         <h2>Select grid type and configuration from dropdown.</h2>
         <div>
-        <strong>Template: </strong><select onChange={(ev) => this.changeType(ev)}>
-          <option name="hexagon">hexagon</option>
-          <option name="triangle">triangle</option>
-          <option name="parallelogram">parallelogram</option>
-          <option name="rectangle">rectangle</option>
-          <option name="orientedRectangle">orientedRectangle</option>
-        </select>
+          <strong>Template: </strong>
+          <select onChange={(ev) => this.changeType(ev)}>
+            {Object.keys(configs).map((type) => (
+              <option name={type}>{type}</option>
+            ))}
+          </select>
         </div>
         <hr />
         <HexGrid width={config.width} height={config.height}>

--- a/examples/templates/src/configurations.json
+++ b/examples/templates/src/configurations.json
@@ -38,5 +38,21 @@
     "origin": { "x": -45, "y": -15 },
     "map": "orientedRectangle",
     "mapProps": [ 7, 7 ]
+  },
+  "ring": {
+    "width": 1000,
+    "height": 800,
+    "layout": { "width": 6, "height": 6, "flat": false, "spacing": 1.1 },
+    "origin": { "x": 0, "y": 0 },
+    "map": "ring",
+    "mapProps": [ {"q":0,"r":0,"s":0}, 3 ]
+  },
+  "spiral": {
+    "width": 1000,
+    "height": 800,
+    "layout": { "width": 6, "height": 6, "flat": false, "spacing": 1.1 },
+    "origin": { "x": 0, "y": 0 },
+    "map": "spiral",
+    "mapProps": [ {"q":0,"r":0,"s":0}, 3 ]
   }
 }

--- a/src/GridGenerator.js
+++ b/src/GridGenerator.js
@@ -25,7 +25,7 @@ class GridGenerator {
   static spiral(center, mapRadius){
     let results = [center];
     for (let k = 1; k <= mapRadius; k++) {
-      const temp = this.ring(center, k);
+      const temp = GridGenerator.ring(center, k);
       results = results.concat(temp);
     }
     return results;


### PR DESCRIPTION
- Fixed bug in GridGenerator where it would call `this` instead of `GridGenerator`
- Refactored selection dropdown in Examples page to list all options in configurations file
- Added configuration options for Spiral and Ring layouts (FINALLY!!)