### PR TITLE
images i cant seem to get inside the hexagon and when i do they become blurry if i increase the height or width #32

### DIFF
--- a/src/Pattern.js
+++ b/src/Pattern.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import HexUtils from './HexUtils';
 import Point from './models/Point';
 
 class Pattern extends Component {
@@ -18,8 +17,8 @@ class Pattern extends Component {
 
     return (
       <defs>
-        <pattern id={id} patternUnits="objectBoundingBox" x={0} y={0} width={size.x} height={size.y}>
-          <image xlinkHref={link} x={0} y={0} width={size.x*2} height={size.y*2} />
+        <pattern id={id} patternUnits="objectBoundingBox" x={0} y={0} width="100%" height="100%">
+          <image xlinkHref={link} x={0} y={0} width={size.x} height={size.y} />
         </pattern>
       </defs>
     );


### PR DESCRIPTION
The fix was to give the pattern 100% width and height. As I noticed the issue was only in the chrome browser when zoom in the hex grid area fill pattern images gets blurred even though it is an SVG image. Please review/approve the change.