### PR TITLE
Patch to make dnd work in firefox.

### DIFF
--- a/src/Hexagon/Hexagon.js
+++ b/src/Hexagon/Hexagon.js
@@ -16,6 +16,7 @@ class Hexagon extends Component {
     ]),
     className: PropTypes.string,
     data: PropTypes.object,
+    onMouseDown: PropTypes.func,
     onMouseEnter: PropTypes.func,
     onMouseOver: PropTypes.func,
     onMouseLeave: PropTypes.func,
@@ -48,6 +49,11 @@ class Hexagon extends Component {
     const hex = new Hex(q, r, s);
     const pixel = HexUtils.hexToPixel(hex, layout);
     this.setState({ hex, pixel });
+  }
+  onMouseDown(e) {
+    if (this.props.onMouseDown) {
+      this.props.onMouseDown(e, this);
+    }
   }
   onMouseEnter(e) {
     if (this.props.onMouseEnter) {
@@ -96,8 +102,9 @@ class Hexagon extends Component {
   onDrop(e) {
     if (this.props.onDrop) {
       e.preventDefault();
-      const target = JSON.parse(e.dataTransfer.getData('hexagon'));
-      this.props.onDrop(e, this, target);
+      //const target = JSON.parse(e.dataTransfer.getData('hexagon'));
+      //this.props.onDrop(e, this, target);
+      this.props.onDrop(e, this, null);
     }
   }
   render() {
@@ -110,6 +117,7 @@ class Hexagon extends Component {
         className={classNames('hexagon-group', className)}
         transform={`translate(${pixel.x}, ${pixel.y})`}
         draggable="true"
+        onMouseDown={e => this.onMouseDown(e)}
         onMouseEnter={e => this.onMouseEnter(e)}
         onMouseOver={e => this.onMouseOver(e)}
         onMouseLeave={e => this.onMouseLeave(e)}


### PR DESCRIPTION
NOTE: This patch is "not" ready to merge, I made this PR as a request for comments/improvements.

It seems like in firefox, svg elements will not have their `onDragStart` function called. They will, however have their `onMouseDown` function called. This patch adds a `onMouseDown` callback, but it also nulls the data stored in the dragging event. Since onMouseDown doesn't seem to let you add information to the drag store, I suspect a shadow store would need to be created in the component's react state.